### PR TITLE
Serial pcap stream

### DIFF
--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -48,12 +48,12 @@ extern bool loggingEnabled;
 #define LOG_TRACE(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #else
 #if defined(DEBUG_PORT) && !defined(DEBUG_MUTE)
-#define LOG_DEBUG(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define LOG_INFO(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__)
-#define LOG_WARN(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__)
-#define LOG_ERROR(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_ERROR, __VA_ARGS__)
-#define LOG_CRIT(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_CRIT, __VA_ARGS__)
-#define LOG_TRACE(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_TRACE, __VA_ARGS__)
+#define LOG_DEBUG(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__) : (void) 0
+#define LOG_INFO(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__) : (void) 0
+#define LOG_WARN(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__) : (void) 0
+#define LOG_ERROR(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_ERROR, __VA_ARGS__) : (void) 0
+#define LOG_CRIT(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_CRIT, __VA_ARGS__) : (void) 0
+#define LOG_TRACE(...) loggingEnabled ? DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_TRACE, __VA_ARGS__) : (void) 0
 #else
 #define LOG_DEBUG(...)
 #define LOG_INFO(...)

--- a/src/DebugConfiguration.h
+++ b/src/DebugConfiguration.h
@@ -2,6 +2,8 @@
 
 #include "configuration.h"
 
+extern bool loggingEnabled;
+
 // DEBUG LED
 #ifndef LED_STATE_ON
 #define LED_STATE_ON 1
@@ -46,12 +48,12 @@
 #define LOG_TRACE(...) SEGGER_RTT_printf(0, __VA_ARGS__)
 #else
 #if defined(DEBUG_PORT) && !defined(DEBUG_MUTE)
-#define LOG_DEBUG(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__)
-#define LOG_INFO(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__)
-#define LOG_WARN(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__)
-#define LOG_ERROR(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_ERROR, __VA_ARGS__)
-#define LOG_CRIT(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_CRIT, __VA_ARGS__)
-#define LOG_TRACE(...) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_TRACE, __VA_ARGS__)
+#define LOG_DEBUG(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_DEBUG, __VA_ARGS__)
+#define LOG_INFO(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_INFO, __VA_ARGS__)
+#define LOG_WARN(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_WARN, __VA_ARGS__)
+#define LOG_ERROR(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_ERROR, __VA_ARGS__)
+#define LOG_CRIT(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_CRIT, __VA_ARGS__)
+#define LOG_TRACE(...) if (loggingEnabled) DEBUG_PORT.log(MESHTASTIC_LOG_LEVEL_TRACE, __VA_ARGS__)
 #else
 #define LOG_DEBUG(...)
 #define LOG_INFO(...)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,6 +185,8 @@ ScanI2C::FoundDevice rgb_found = ScanI2C::FoundDevice(ScanI2C::DeviceType::NONE,
 Adafruit_DRV2605 drv;
 #endif
 
+bool loggingEnabled = true;
+
 // Global LoRa radio type
 LoRaRadioType radioType = NO_RADIO;
 

--- a/src/modules/exploiteers_pager/apps/pcap/pcap_window.cpp
+++ b/src/modules/exploiteers_pager/apps/pcap/pcap_window.cpp
@@ -90,6 +90,9 @@ void PcapWindow::repaint(U8G2& u8g2)
     
     const char* buttonStr = pcap.isLogging() ? "End" : "Start";
     u8g2.drawStr(159 - u8g2.getStrWidth(buttonStr) / 2, 36, buttonStr);
+
+    const char* infoButtonStr = (pcap.isLogging() && pcap.isLogToSerial()) ? "End" : "Start";
+    u8g2.drawStr(159 - u8g2.getStrWidth(infoButtonStr) / 2, 49, infoButtonStr);
     
     RadioParams rp = pcap.getRadioParams();
     std::string preset;
@@ -292,13 +295,38 @@ void PcapWindow::onEvent(int event) {
                 dialogOptions, i, true
             )));
         } else if (selected == Buttons::INFO) {
+            if (!pcap.isLogging()) {
+                pcap.setLogToSerial(true);      // Enable serial logging
+                pcap.beginPacketLog();          // Start logging
+            } else {
+                stopCapture();                  // End logging
+                pcap.setLogToSerial(false);     // Disable serial logging
+            }
+        } else if (selected == Buttons::FREQ) {
+            dm.addWindow(std::unique_ptr<Window>(new KeyboardWindow(btn_save_bits, "Enter frequency")));
+        } else if (selected == Buttons::SF) {
             dm.addWindow(std::unique_ptr<Window>(new DialogWindow(
-                DialogWindow::Style::Buttons,
-                {
-                    "View captured packets with",
-                    "https://hackerpager.net",
-                    "           /wireshark-plugin"
-                }, {{"OK", ""}}
+                DialogWindow::Style::Spinner,
+                {"Spreading factor:"},
+                {{"12", "12"}, {"11", "11"}, {"10", "10"}, {"9", "9"}, {"8", "8"}}
+            )));
+        } else if (selected == Buttons::CR) {
+            dm.addWindow(std::unique_ptr<Window>(new DialogWindow(
+                DialogWindow::Style::Spinner,
+                {"Coding rate:"},
+                {{"4/5", "4/5"}, {"4/6", "4/6"}, {"4/7", "4/7"}, {"4/8", "4/8"}}
+            )));
+        } else if (selected == Buttons::BW) {
+            dm.addWindow(std::unique_ptr<Window>(new DialogWindow(
+                DialogWindow::Style::Spinner,
+                {"Bandwidth:"},
+                {{"125 kHz", "125000"}, {"250 kHz", "250000"}, {"500 kHz", "500000"}}
+            )));
+        } else if (selected == Buttons::SW) {
+            dm.addWindow(std::unique_ptr<Window>(new DialogWindow(
+                DialogWindow::Style::Spinner,
+                {"Sync word:"},
+                {{"0x12", "0x12"}, {"0x34", "0x34"}, {"0x78", "0x78"}}
             )));
         } else if (selected == Buttons::LIMIT) {
             dm.addWindow(std::unique_ptr<Window>(new DialogWindow(

--- a/src/modules/exploiteers_pager/apps/pcap/pcap_window.cpp
+++ b/src/modules/exploiteers_pager/apps/pcap/pcap_window.cpp
@@ -296,11 +296,13 @@ void PcapWindow::onEvent(int event) {
             )));
         } else if (selected == Buttons::INFO) {
             if (!pcap.isLogging()) {
+                loggingEnabled = false;
                 pcap.setLogToSerial(true);      // Enable serial logging
                 pcap.beginPacketLog();          // Start logging
             } else {
                 stopCapture();                  // End logging
                 pcap.setLogToSerial(false);     // Disable serial logging
+                loggingEnabled = true;
             }
         } else if (selected == Buttons::FREQ) {
             dm.addWindow(std::unique_ptr<Window>(new KeyboardWindow(btn_save_bits, "Enter frequency")));

--- a/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
+++ b/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
@@ -35,16 +35,12 @@ void PacketCapture::logPacket(uint8_t *data, size_t length, boolean isSend)
     }
 
     if (logToSerial) {
-        loggingEnabled = false;
-
         for (size_t i = 0; i < length; ++i) {
             if (data[i] < 16) Serial.print("0"); // leading zero for single digit
             DEBUG_PORT.print(data[i], HEX);
             DEBUG_PORT.print(" ");
         }
         DEBUG_PORT.println();
-
-        loggingEnabled = true;
     }
 
     // Log raw bytes to serial console

--- a/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
+++ b/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
@@ -35,12 +35,16 @@ void PacketCapture::logPacket(uint8_t *data, size_t length, boolean isSend)
     }
 
     if (logToSerial) {
+        loggingEnabled = false;
+
         for (size_t i = 0; i < length; ++i) {
             if (data[i] < 16) Serial.print("0"); // leading zero for single digit
             DEBUG_PORT.print(data[i], HEX);
             DEBUG_PORT.print(" ");
         }
         DEBUG_PORT.println();
+
+        loggingEnabled = true;
     }
 
     // Log raw bytes to serial console

--- a/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
+++ b/src/modules/exploiteers_pager/packetcapture/packet_capture.cpp
@@ -34,6 +34,24 @@ void PacketCapture::logPacket(uint8_t *data, size_t length, boolean isSend)
         return;
     }
 
+    if (logToSerial) {
+        for (size_t i = 0; i < length; ++i) {
+            if (data[i] < 16) Serial.print("0"); // leading zero for single digit
+            DEBUG_PORT.print(data[i], HEX);
+            DEBUG_PORT.print(" ");
+        }
+        DEBUG_PORT.println();
+    }
+
+    // Log raw bytes to serial console
+    LOG_INFO("[Meshtastic Packet] Raw bytes: ");
+    for (size_t i = 0; i < length; ++i) {
+        if (data[i] < 16) Serial.print("0"); // leading zero for single digit
+        DEBUG_PORT.print(data[i], HEX);
+        DEBUG_PORT.print(" ");
+    }
+    DEBUG_PORT.println();
+
     const auto time = std::chrono::system_clock::now();
     int64_t timeMicros = std::chrono::duration_cast<std::chrono::microseconds>(time.time_since_epoch()).count();
     pcap_packet p{

--- a/src/modules/exploiteers_pager/packetcapture/packet_capture.h
+++ b/src/modules/exploiteers_pager/packetcapture/packet_capture.h
@@ -54,6 +54,8 @@ class PacketCapture
     std::vector<LoRaWanPreset> wanPreset;  // Because std::optional is too new.
     std::vector<pcap_packet> packetLog;
 
+    void setLogToSerial(bool enabled) { logToSerial = enabled; }
+    bool isLogToSerial() const { return logToSerial; }
     void setRadio(SX1262Interface *rIf);
     void beginPacketLog();
     void logPacket(uint8_t *data, size_t length, bool isSend);
@@ -74,6 +76,8 @@ class PacketCapture
    private:
     bool loggingPackets = false;
     SX1262Interface *sx1262 = nullptr;
+
+    bool logToSerial = false;
 
     bool savedInitialParams = false;
     RadioParams initialRadioParams;


### PR DESCRIPTION
HOW TO USE:
- Flash this firmware
- Go to Tools > Capture, click the weird button in the bottom right that both says "Start" and "Info" at the same time (working on it).
- Plug the Pager into your computer
- Use screen to view the serial output. If you're on a mac, the instructions are below:

Get path to pager with `ls /dev/tty.*`
View console output with `screen /dev/tty.usbmodemlotsofrandomnumbers 115200`
To exit screen: `Ctrl-A`, then `K`, then `Y`.

TASKS DONE:
- Turned the Info button into a Live capture button. In live capture mode all packets are logged directly as hex to the serial console and all other logs are turned off. Turn off live mode to turn regular logging back on.

TASKS STILL TO DO:
- Decouple the live mode and the capture to SD card mode. Currently it turns on both live mode and capture to SD card mode, and is likely still limited by the max of 1024 packets.
- Rename live button to "Live Cap"
- Figure out where "Info" is being drawn onto the button from and delete that.